### PR TITLE
Fixing rules engine values for the advance overtime example.

### DIFF
--- a/source/includes/APIReference/Reports/Examples/_payroll_by_jobcode-explanation-2.md.erb
+++ b/source/includes/APIReference/Reports/Examples/_payroll_by_jobcode-explanation-2.md.erb
@@ -14,7 +14,7 @@
                                         #   contained in the report.
         "82026": {                      # Jobcode ID
           "jobcode_id": 82026,           
-          "total_re_seconds": 0,        # Total regular seconds for this jobcode.
+          "total_re_seconds": 10800     # Total regular seconds for this jobcode.
           "total_pto_seconds": 28800,   # Total PTO seconds for this jobcode.
           "total_work_seconds": 28800,  # Total number of seconds for this jobcode.
           "overtime_seconds": {         # This replaces "total_ot_seconds" 
@@ -44,7 +44,7 @@
           "totals": {                   # Totals for each jobcode, for this user.
             "82026": {                  # Jobcode ID
               "jobcode_id": 82026,         
-              "total_re_seconds": 0,
+              "total_re_seconds": 10800,
               "total_pto_seconds": 28800,
               "total_work_seconds": 28800
               "overtime_seconds": {           
@@ -72,7 +72,7 @@
             "2017-03-15": {             # Date
               "82026": {                # Jobcode ID
                 "jobcode_id": 82026,        
-                "total_re_seconds": 0,
+                "total_re_seconds": 10800,
                 "total_pto_seconds": 28800,
                 "total_unpaid_seconds": 0,
                 "total_work_seconds": 28800


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->