### PR TITLE
Adding an aside to explain that payroll_id can be found in supplement…

### DIFF
--- a/source/includes/APIReference/Reports/Examples/_payroll-response.md.erb
+++ b/source/includes/APIReference/Reports/Examples/_payroll-response.md.erb
@@ -88,28 +88,56 @@
         "employee_number": 3333,
         "salaried": false,
         "exempt": false,
-        ...
+        "username": "hford",
+        "email": "indy.jones@anymail.com",
+        "email_verified": false,
+        "payroll_id": "SC010",
+        "hire_date": "2017-07-02",
+        "term_date": "0000-00-00",
+        "last_modified": "2019-02-20T18:53:08+00:00",
+        "last_active": "2019-02-11T20:14:28+00:00",
+        "created": "2017-07-02T12:25:38+00:00",
+        "client_url": "spudsfunpark",
+        "company_name": "Spuds Fun Park",
+        "profile_image_url": "https://www.gravatar.com/avatar/6be49c2065c016dcdfcd26d1da111e9f",
+        "mobile_number": "2085551234",
+        "pto_balances": {
+          "2913946": 0,
+          "2913948": 0,
+          "2913950": 0
+        },
+        "submitted_to": "2018-03-15",
+        "approved_to": "2018-03-15",
+        "manager_of_group_ids": [],
+        "require_password_change": false,
+        "pay_rate": 8.25,
+        "pay_interval": "hour",
+        "permissions": {
+          "admin": false,
+          "mobile": true,
+          "status_box": false,
+          ...
+        },
+        "customfields": ""
       }
-    }
-  },
-  "jobcodes": {
-    "12074": {
-      "id": 12074,
-      "parent_id": 0,
-      "assigned_to_all": false,
-      "billable": false,
-      "active": true,
-      "type": "pto",
-      "has_children": false,
-      "billable_rate": 0,
-      "short_code": "",
-      "name": "Holiday",
-      "last_modified": "2018-03-18T17:58:52+00:00",
-      "created": "2017-04-01T17:20:24+00:00",
-      "required_customfields": [
-
-      ],
-      "filtered_customfielditems": ""
+    },
+    "jobcodes": {
+      "12074": {
+        "id": 12074,
+        "parent_id": 0,
+        "assigned_to_all": false,
+        "billable": false,
+        "active": true,
+        "type": "pto",
+        "has_children": false,
+        "billable_rate": 0,
+        "short_code": "",
+        "name": "Holiday",
+        "last_modified": "2018-03-18T17:58:52+00:00",
+        "created": "2017-04-01T17:20:24+00:00",
+        "required_customfields": [ ],
+        "filtered_customfielditems":""
+      }
     }
   }
 }

--- a/source/includes/APIReference/Reports/_payroll.md.erb
+++ b/source/includes/APIReference/Reports/_payroll.md.erb
@@ -28,3 +28,7 @@ _Pass an an object of filters as the value to a 'data' property (see example)._
 See explanation of response layouts to the right.
 
 Notice in the advanced overtime layout that the `total_ot_seconds` and `total_dt_seconds` values have been replaced by the `overtime_seconds` and `fixed_rate_seconds` objects in each instance. In the `overtime_seconds` object the key is the multiplier rate and the value is the number of seconds of overtime at that rate (i.e 14400 seconds at 1.5x). In the `fixed_rate_seconds` object, the key is the additional rate amount to add to the employee's hourly rate and the value is the time in seconds.
+
+<aside class="notice">
+The <code>payroll_id</code> value for each user can be found within the <code>supplemental_data</code> section of the response.  See example.
+</aside>


### PR DESCRIPTION
…al data, as well as fixing the previously truncated example to include the field.  Why? ADP Integrations team assumed the Payroll Report API endpoint didn't include the payroll_id field, and was making a call to the user object to first get the Payroll_id, then making another request to the Payroll Report. They were getting HTTP 429 (Too Many Requests) Their API calls should drop by about 50% once they start getting the payroll_id from the payroll report.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->